### PR TITLE
Add support for "Freedom Teams"

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -11,8 +11,10 @@ export interface Config {
   skipKeywords: string[]
   useReviewGroups: boolean
   useAssigneeGroups: boolean
+  useFreedomTeams: boolean
   reviewGroups: { [key: string]: string[] }
   assigneeGroups: { [key: string]: string[] }
+  freedomTeams: { [key: string]: string[] }
   skipUsers: string[]
 }
 


### PR DESCRIPTION
Accepts new configuration to use "Freedom Teams". It works in conjuction with top-level reviewers, but doesn't work with review groups (if review groups are used everything else is disabled).

The logic is as follows:

* assuming the `numberOfReviewers` is _n_, then
* if the owner is a part of a team, _n_ reviewers will be selected from that team
* if the owner is not a part of a team, _n_ random reviewers will be selected across all teams
* additionally, _n_ reviewers will be selected from the top-level list of reviewers filtering out any already selected reviewers

This guarantees that we will not attempt to assign the same person twice as a reviewer giving the code a little bit more of a deterministic behavior.